### PR TITLE
Initial checking of Placeholders for KMeans Speed Layer

### DIFF
--- a/oryx-app-mllib/src/main/java/com/cloudera/oryx/app/mllib/kmeans/KMeansUpdate.java
+++ b/oryx-app-mllib/src/main/java/com/cloudera/oryx/app/mllib/kmeans/KMeansUpdate.java
@@ -147,7 +147,8 @@ public class KMeansUpdate extends MLUpdate<String> {
             ClusteringModel.ModelClass.CENTER_BASED,
             model.clusterCenters().length)
             .withAlgorithmName("K-Means||")
-            .withNumberOfClusters(model.k());
+            .withNumberOfClusters(model.k())
+            .withScorable(true);
 
     Vector[] clusterCenters = model.clusterCenters();
     for (int i = 0; i < clusterCenters.length; i++) {

--- a/oryx-app-mllib/src/test/java/com/cloudera/oryx/app/mllib/kmeans/KMeansUpdateIT.java
+++ b/oryx-app-mllib/src/test/java/com/cloudera/oryx/app/mllib/kmeans/KMeansUpdateIT.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.typesafe.config.Config;
+import org.dmg.pmml.Cluster;
 import org.dmg.pmml.ClusteringModel;
 import org.dmg.pmml.ComparisonMeasure;
 import org.dmg.pmml.Model;
@@ -33,18 +34,17 @@ import com.cloudera.oryx.common.collection.Pair;
 import com.cloudera.oryx.common.io.IOUtils;
 import com.cloudera.oryx.common.pmml.PMMLUtils;
 import com.cloudera.oryx.common.settings.ConfigUtils;
-import com.cloudera.oryx.lambda.AbstractBatchIT;
 import com.cloudera.oryx.ml.MLUpdate;
 
-public final class KMeansUpdateIT extends AbstractBatchIT {
+public final class KMeansUpdateIT extends AbstractKMeansIT {
 
   private static final Logger log = LoggerFactory.getLogger(KMeansUpdateIT.class);
 
-  private static final int DATA_TO_WRITE = 1000;
+  private static final int DATA_TO_WRITE = 2000;
   private static final int WRITE_INTERVAL_MSEC = 10;
   private static final int GEN_INTERVAL_SEC = 10;
   private static final int BLOCK_INTERVAL_SEC = 1;
-  private static final int CLUSTERS = 3;
+  private static final int CLUSTERS = 5;
 
   @Test
   public void testKMeans() throws Exception {
@@ -104,8 +104,9 @@ public final class KMeansUpdateIT extends AbstractBatchIT {
       // Check if Basic hyperparameters match
       assertEquals(Integer.valueOf(CLUSTERS), clusteringModel.getNumberOfClusters());
       assertEquals(ComparisonMeasure.Kind.DISTANCE, clusteringModel.getComparisonMeasure().getKind());
-
-      assertTrue(clusteringModel.getClusters().get(0).getArray().getN() == 2);
+      List<Cluster> clusters = clusteringModel.getClusters();
+      Cluster cluster = clusters.get(0);
+      assertTrue(cluster.getArray().getN() == 2);
 
     }
   }

--- a/oryx-app-mllib/src/test/java/com/cloudera/oryx/app/mllib/kmeans/RandomKMeansDataGenerator.java
+++ b/oryx-app-mllib/src/test/java/com/cloudera/oryx/app/mllib/kmeans/RandomKMeansDataGenerator.java
@@ -39,7 +39,6 @@ final class RandomKMeansDataGenerator implements DatumGenerator<String,String> {
 			double d = random.nextDouble();
 			elements.add(Double.toString(d));
 		}
-		TextUtils.joinCSV(elements);
 		return new Pair<>(Integer.toString(id), TextUtils.joinCSV(elements));
 	}
 }

--- a/oryx-app-mllib/src/test/java/com/cloudera/oryx/app/mllib/rdf/RandomRDFDataGenerator.java
+++ b/oryx-app-mllib/src/test/java/com/cloudera/oryx/app/mllib/rdf/RandomRDFDataGenerator.java
@@ -53,7 +53,6 @@ final class RandomRDFDataGenerator implements DatumGenerator<String,String> {
       elements.add(Double.toString(d));
     }
     elements.add(Boolean.toString(positive));
-    TextUtils.joinCSV(elements);
     return new Pair<>(Integer.toString(id), TextUtils.joinCSV(elements));
   }
 

--- a/oryx-app/src/main/java/com/cloudera/oryx/app/speed/kmeans/KMeansSpeedModel.java
+++ b/oryx-app/src/main/java/com/cloudera/oryx/app/speed/kmeans/KMeansSpeedModel.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2014, Cloudera, Inc. All Rights Reserved.
+ *
+ * Cloudera, Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"). You may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for
+ * the specific language governing permissions and limitations under the
+ * License.
+ */
+
+package com.cloudera.oryx.app.speed.kmeans;
+
+import com.cloudera.oryx.common.collection.Pair;
+import java.util.ArrayList;
+import java.util.List;
+
+public final class KMeansSpeedModel {
+
+	private final List<Pair<Double,Integer>> clusters;
+
+	public KMeansSpeedModel(Double[] clusterCenters) {
+		this.clusters = new ArrayList<>();
+	}
+
+
+
+
+
+}

--- a/oryx-app/src/main/java/com/cloudera/oryx/app/speed/kmeans/KMeansSpeedModelManager.java
+++ b/oryx-app/src/main/java/com/cloudera/oryx/app/speed/kmeans/KMeansSpeedModelManager.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2014, Cloudera, Inc. All Rights Reserved.
+ *
+ * Cloudera, Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"). You may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for
+ * the specific language governing permissions and limitations under the
+ * License.
+ */
+
+package com.cloudera.oryx.app.speed.kmeans;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Iterator;
+
+import org.apache.spark.api.java.JavaPairRDD;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.cloudera.oryx.lambda.KeyMessage;
+import com.cloudera.oryx.lambda.speed.SpeedModelManager;
+
+public final class KMeansSpeedModelManager implements SpeedModelManager<String,String,String> {
+
+	private static final Logger log = LoggerFactory.getLogger(KMeansSpeedModelManager.class);
+
+	private KMeansSpeedModel model;
+
+	@Override
+	public void consume(Iterator<KeyMessage<String, String>> updateIterator) throws IOException {
+		while (updateIterator.hasNext()) {
+			KeyMessage<String,String> km = updateIterator.next();
+			String key = km.getKey();
+			String message = km.getMessage();
+			switch(key) {
+				case "UP":
+					break;
+				case "MODEL":
+					break;
+			}
+		}
+
+	}
+
+	@Override
+	public Iterable<String> buildUpdates(JavaPairRDD<String, String> newData) throws IOException {
+		if (model == null) {
+			return Collections.emptyList();
+		}
+
+
+		return null;
+	}
+
+	@Override
+	public void close() {
+		// do nothing
+	}
+}


### PR DESCRIPTION
removed extra call to TextUtils.join() in RandomKMeansDataGenerator and RandomRDFDataGenerator
