### PR TITLE
Last change for Jacoco:integration-test is causing the build tests to fail, fixed a javadoc warning in DoubleWeightedMean

### DIFF
--- a/oryx-app-mllib/src/test/java/com/cloudera/oryx/app/mllib/kmeans/KMeansUpdateIT.java
+++ b/oryx-app-mllib/src/test/java/com/cloudera/oryx/app/mllib/kmeans/KMeansUpdateIT.java
@@ -57,7 +57,7 @@ public final class KMeansUpdateIT extends AbstractKMeansIT {
     overlayConfig.put("oryx.batch.streaming.block-interval-sec", BLOCK_INTERVAL_SEC);
     overlayConfig.put("oryx.kmeans.hyperparams.k", CLUSTERS);
     overlayConfig.put("oryx.input-schema.num-features", 5);
-    overlayConfig.put("oryx.input-schema.numeric-features", "[\"0\",\"1\",\"2\",\"3\",\"4\"]");
+    overlayConfig.put("oryx.input-schema.categorical-features", "[]");
     overlayConfig.put("oryx.kmeans.iterations", 5);
 
     Config config = ConfigUtils.overlayOn(overlayConfig, getConfig());

--- a/oryx-common/src/main/java/com/cloudera/oryx/common/math/DoubleWeightedMean.java
+++ b/oryx-common/src/main/java/com/cloudera/oryx/common/math/DoubleWeightedMean.java
@@ -21,6 +21,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.primitives.Doubles;
 import com.google.common.primitives.Longs;
 import org.apache.commons.math3.stat.descriptive.AbstractStorelessUnivariateStatistic;
+import org.apache.commons.math3.stat.descriptive.moment.Mean;
 
 /**
  * <p>A weighted mean implementation for floating-point weights, following the Commons
@@ -28,7 +29,7 @@ import org.apache.commons.math3.stat.descriptive.AbstractStorelessUnivariateStat
  *
  * <p>This class is not thread-safe.</p>
  *
- * @see org.apache.commons.math3.stat.descriptive.moment.Mean
+ * @see Mean
  */
 public final class DoubleWeightedMean
     extends AbstractStorelessUnivariateStatistic implements Serializable {

--- a/pom.xml
+++ b/pom.xml
@@ -643,7 +643,7 @@
           <version>2.18.1</version>
           <configuration>
             <!-- sun.io.serialization.extendedDebugInfo helps debug NotSerializableException problems -->
-            <argLine>-Dsun.io.serialization.extendedDebugInfo=true -Dlog4j.configuration=log4j.test.properties ${argLine}</argLine>
+            <argLine>-Dsun.io.serialization.extendedDebugInfo=true -Dlog4j.configuration=log4j.test.properties</argLine>
           </configuration>
         </plugin>
         <plugin>
@@ -660,7 +660,7 @@
           </executions>
           <configuration>
             <!-- sun.io.serialization.extendedDebugInfo helps debug NotSerializableException problems -->
-            <argLine>-Dsun.io.serialization.extendedDebugInfo=true -Dlog4j.configuration=log4j.test.properties ${argLine}</argLine>
+            <argLine>-Dsun.io.serialization.extendedDebugInfo=true -Dlog4j.configuration=log4j.test.properties</argLine>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
Seeing the following exception following the last changes for jacoco:integration-test

{Code}

ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:2.18.1:test (default-test) on project oryx-common: Execution default-test of goal org.apache.maven.plugins:maven-surefire-plugin:2.18.1:test failed: The forked VM terminated without properly saying goodbye. VM crash or System.exit called?
[ERROR] Command was /bin/sh -c cd /Users/smarthi/oryx/oryx-common && /Library/Java/JavaVirtualMachines/jdk1.7.0_45.jdk/Contents/Home/jre/bin/java -Dsun.io.serialization.extendedDebugInfo=true -Dlog4j.configuration=log4j.test.properties '${argLine}' -jar /Users/smarthi/oryx/oryx-common/target/surefire/surefirebooter3025250885663699237.jar /Users/smarthi/oryx/oryx-common/target/surefire/surefire5425991463041310029tmp /Users/smarthi/oryx/oryx-common/target/surefire/surefire_02981337457646555982tmp
[ERROR] -> [Help 1]

{Code}

Undoing the last changes, got past this error, due to unresolved ${argLine}.

Fix for the following javadoc warning:

[WARNING] Javadoc Warnings
[WARNING] /Users/smarthi/oryx/oryx-common/src/main/java/com/cloudera/oryx/common/math/DoubleWeightedMean.java:33: warning - Tag @see: reference not found: org.apache.commons.math3.stat.descriptive.moment.Mean
