### PR TITLE
- Fixed link in markdown/docs/index.md

### DIFF
--- a/src/site/markdown/docs/index.md
+++ b/src/site/markdown/docs/index.md
@@ -602,7 +602,7 @@ Oryx 2 contains the same set of end-to-end ML applications as Oryx 1, and expose
 
 #### Configuration
 
-Both implementations use a single configuration file parsed by Typesafe Config. The property namespaces are different but there are some similarities. Compare the [Oryx 1 configuration](https://github.com/cloudera/oryx/blob/master/common/src/main/resources/reference.conf) to the [Oryx 2 configuration](https://github.com/OryxProject/oryx/blob/master/oryx-common/src/main/resources/reference.conf) to understand some of the correspondence and difference.
+Both implementations use a single configuration file parsed by Typesafe Config. The property namespaces are different but there are some similarities. Compare the [Oryx 1 configuration](https://github.com/cloudera/oryx/blob/master/common/src/main/resources/reference.conf) to the [Oryx 2 configuration](https://github.com/OryxProject/oryx/blob/master/framework/oryx-common/src/main/resources/reference.conf) to understand some of the correspondence and difference.
 
 #### Data Storage and Transport
 


### PR DESCRIPTION
Fixes link in markdown/docs/index.md. In the configuration part of the differences from Oryx 1 section, the Oryx 2 configuration link points to https://github.com/OryxProject/oryx/blob/master/oryx-common/src/main/resources/reference.conf which do not exist, the correct link should be https://github.com/OryxProject/oryx/blob/master/framework/oryx-common/src/main/resources/reference.conf 