### PR TITLE
Add `oryx.{serving,speed}.min-model-load-fraction` to control how much of the model must load in speed or serving layer before it is considered loaded

### DIFF
--- a/app/example/src/main/java/com/cloudera/oryx/example/ExampleServingModelManager.java
+++ b/app/example/src/main/java/com/cloudera/oryx/example/ExampleServingModelManager.java
@@ -21,6 +21,7 @@ import java.util.Iterator;
 import java.util.Map;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.typesafe.config.Config;
 import org.apache.hadoop.conf.Configuration;
 
 import com.cloudera.oryx.api.KeyMessage;
@@ -34,7 +35,12 @@ import com.cloudera.oryx.api.serving.ServingModelManager;
  */
 public final class ExampleServingModelManager implements ServingModelManager<String> {
 
+  private final Config config;
   private final Map<String,Integer> distinctOtherWords = new HashMap<>();
+
+  public ExampleServingModelManager(Config config) {
+    this.config = config;
+  }
 
   @Override
   public void consume(Iterator<KeyMessage<String,String>> updateIterator, Configuration hadoopConf) throws IOException {
@@ -61,6 +67,11 @@ public final class ExampleServingModelManager implements ServingModelManager<Str
           break;
       }
     }
+  }
+
+  @Override
+  public Config getConfig() {
+    return config;
   }
 
   @Override

--- a/app/example/src/main/scala/com/cloudera/oryx/example/ExampleScalaServingModelManager.scala
+++ b/app/example/src/main/scala/com/cloudera/oryx/example/ExampleScalaServingModelManager.scala
@@ -15,6 +15,8 @@
 
 package com.cloudera.oryx.example
 
+import com.typesafe.config.Config
+
 import scala.collection.{mutable, JavaConversions}
 
 import com.fasterxml.jackson.databind.ObjectMapper
@@ -29,7 +31,7 @@ import com.cloudera.oryx.api.serving.ScalaServingModelManager
  * Updates are "word,count" pairs representing new counts for a word. This class manages and exposes the
  * mapping to the Serving Layer applications.
  */
-class ExampleScalaServingModelManager extends ScalaServingModelManager[String] {
+class ExampleScalaServingModelManager(val config: Config) extends ScalaServingModelManager[String] {
 
   private val distinctOtherWords = mutable.Map[String,Integer]()
 
@@ -55,6 +57,8 @@ class ExampleScalaServingModelManager extends ScalaServingModelManager[String] {
       }
     )
   }
+
+  override def getConfig = config
 
   override def getModel = distinctOtherWords
 

--- a/app/oryx-app-common/src/main/java/com/cloudera/oryx/app/als/FeatureVectors.java
+++ b/app/oryx-app-common/src/main/java/com/cloudera/oryx/app/als/FeatureVectors.java
@@ -48,16 +48,30 @@ public final class FeatureVectors {
     lock = new AutoReadWriteLock();
   }
 
+  /**
+   * @return number of IDs / feature vectors
+   */
   public int size() {
     return vectors.size();
   }
 
+  /**
+   * @param id ID to get feature vector for
+   * @return feature vector for ID, or {@code null} if doesn't exist
+   */
   public float[] getVector(String id) {
     try (AutoLock al = lock.autoReadLock()) {
       return vectors.get(id);
     }
   }
 
+  /**
+   * Sets the value of a feature vector for an ID. If no feature vector previously existed,
+   * it is considered a "recent" ID until the next {@link #retainRecentAndIDs(Collection)} call.
+   *
+   * @param id ID to set feature vector for
+   * @param vector new feature vector
+   */
   public void setVector(String id, float[] vector) {
     try (AutoLock al = lock.autoWriteLock()) {
       if (vectors.put(id, vector) == null) {
@@ -67,6 +81,9 @@ public final class FeatureVectors {
     }
   }
 
+  /**
+   * @param id ID to remove feature vector for
+   */
   public void removeVector(String id) {
     try (AutoLock al = lock.autoWriteLock()) {
       vectors.remove(id);
@@ -74,20 +91,47 @@ public final class FeatureVectors {
     }
   }
 
+  /**
+   * Adds all IDs that are mapped to a feature vector to a given collection
+   *
+   * @param allIDs collection to add IDs to
+   */
   public void addAllIDsTo(Collection<String> allIDs) {
     try (AutoLock al = lock.autoReadLock()) {
       allIDs.addAll(vectors.keySet());
     }
   }
 
+  /**
+   * Removes all IDs that are mapped to a feature vector from a given collection
+   *
+   * @param allIDs collection to add IDs to
+   */
+  public void removeAllIDsFrom(Collection<String> allIDs) {
+    try (AutoLock al = lock.autoReadLock()) {
+      allIDs.removeAll(vectors.keySet());
+    }
+  }
+
+  /**
+   * Add all recently set IDs to the given collection
+   *
+   * @param allRecent collection to add IDs to
+   */
   public void addAllRecentTo(Collection<String> allRecent) {
     try (AutoLock al = lock.autoReadLock()) {
       allRecent.addAll(recentIDs);
     }
   }
 
-  public void prune(Collection<String> newModelIDs) {
-    // Keep all IDs in the new model, or, that have been added since last model
+  /**
+   * Given IDs that are part of a new model, and whose values are going to be sent later,
+   * retain only IDs that are also in the new model (or have been recently seen -- possibly since
+   * last model was built), and remove the rest.
+   *
+   * @param newModelIDs new model IDs
+   */
+  public void retainRecentAndIDs(Collection<String> newModelIDs) {
     try (AutoLock al = lock.autoWriteLock()) {
       vectors.removeIf(new KeyOnlyBiPredicate<>(Predicates.and(
           new NotContainsPredicate<>(newModelIDs), new NotContainsPredicate<>(recentIDs))));
@@ -95,16 +139,27 @@ public final class FeatureVectors {
     }
   }
 
+  /**
+   * @param action function to apply to every ID/vector pair
+   */
   public void forEach(BiConsumer<String,float[]> action) {
     try (AutoLock al = lock.autoReadLock()) {
       vectors.forEach(action);
     }
   }
 
+  /**
+   * @return considering the feature vectors as the rows of a matrix V, this computes V^T * V
+   */
   public RealMatrix getVTV() {
     try (AutoLock al = lock.autoReadLock()) {
       return VectorMath.transposeTimesSelf(vectors.values());
     }
+  }
+
+  @Override
+  public String toString() {
+    return "FeatureVectors[size:" + size() + "]";
   }
 
 }

--- a/app/oryx-app-serving/src/main/java/com/cloudera/oryx/app/serving/kmeans/model/KMeansServingModelManager.java
+++ b/app/oryx-app-serving/src/main/java/com/cloudera/oryx/app/serving/kmeans/model/KMeansServingModelManager.java
@@ -43,10 +43,12 @@ public final class KMeansServingModelManager implements ServingModelManager<Stri
   private static final Logger log = LoggerFactory.getLogger(KMeansServingModelManager.class);
   private static final ObjectMapper MAPPER = new ObjectMapper();
 
+  private final Config config;
   private final InputSchema inputSchema;
   private KMeansServingModel model;
 
   public KMeansServingModelManager(Config config) {
+    this.config = config;
     inputSchema = new InputSchema(config);
   }
 
@@ -94,6 +96,11 @@ public final class KMeansServingModelManager implements ServingModelManager<Stri
           throw new IllegalArgumentException("Bad message: " + km);
       }
     }
+  }
+
+  @Override
+  public Config getConfig() {
+    return config;
   }
 
   @Override

--- a/app/oryx-app-serving/src/main/java/com/cloudera/oryx/app/serving/rdf/model/RDFServingModelManager.java
+++ b/app/oryx-app-serving/src/main/java/com/cloudera/oryx/app/serving/rdf/model/RDFServingModelManager.java
@@ -49,10 +49,12 @@ public final class RDFServingModelManager implements ServingModelManager<String>
   private static final Logger log = LoggerFactory.getLogger(RDFServingModelManager.class);
   private static final ObjectMapper MAPPER = new ObjectMapper();
 
+  private final Config config;
   private final InputSchema inputSchema;
   private RDFServingModel model;
 
   public RDFServingModelManager(Config config) {
+    this.config = config;
     inputSchema = new InputSchema(config);
   }
 
@@ -123,6 +125,11 @@ public final class RDFServingModelManager implements ServingModelManager<String>
           throw new IllegalArgumentException("Bad message: " + km);
       }
     }
+  }
+
+  @Override
+  public Config getConfig() {
+    return config;
   }
 
   @Override

--- a/app/oryx-app-serving/src/test/java/com/cloudera/oryx/app/serving/als/AbstractALSServingTest.java
+++ b/app/oryx-app-serving/src/test/java/com/cloudera/oryx/app/serving/als/AbstractALSServingTest.java
@@ -23,6 +23,7 @@ import javax.servlet.ServletContextListener;
 import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.MediaType;
 
+import com.typesafe.config.Config;
 import org.junit.Assert;
 
 import com.cloudera.oryx.app.serving.AbstractOryxResource;
@@ -30,6 +31,7 @@ import com.cloudera.oryx.app.serving.IDCount;
 import com.cloudera.oryx.app.serving.IDValue;
 import com.cloudera.oryx.app.serving.als.model.ALSServingModel;
 import com.cloudera.oryx.app.serving.als.model.TestALSModelFactory;
+import com.cloudera.oryx.common.settings.ConfigUtils;
 import com.cloudera.oryx.lambda.serving.AbstractServingTest;
 import com.cloudera.oryx.lambda.serving.MockTopicProducer;
 
@@ -58,11 +60,14 @@ public abstract class AbstractALSServingTest extends AbstractServingTest {
       context.setAttribute(AbstractOryxResource.INPUT_PRODUCER_KEY, new MockTopicProducer());
     }
     protected MockServingModelManager getModelManager() {
-      return new MockServingModelManager();
+      return new MockServingModelManager(ConfigUtils.getDefault());
     }
   }
 
   protected static class MockServingModelManager extends AbstractMockServingModelManager {
+    public MockServingModelManager(Config config) {
+      super(config);
+    }
     @Override
     public ALSServingModel getModel() {
       return TestALSModelFactory.buildTestModel();

--- a/app/oryx-app-serving/src/test/java/com/cloudera/oryx/app/serving/als/LoadBenchmark.java
+++ b/app/oryx-app-serving/src/test/java/com/cloudera/oryx/app/serving/als/LoadBenchmark.java
@@ -24,6 +24,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import javax.servlet.ServletContextListener;
 import javax.ws.rs.core.MediaType;
 
+import com.typesafe.config.Config;
 import org.apache.commons.math3.random.RandomGenerator;
 import org.apache.commons.math3.stat.descriptive.moment.Mean;
 import org.glassfish.jersey.test.TestProperties;
@@ -36,6 +37,7 @@ import com.cloudera.oryx.common.lang.LoggingVoidCallable;
 import com.cloudera.oryx.common.random.RandomManager;
 import com.cloudera.oryx.app.serving.als.model.ALSServingModel;
 import com.cloudera.oryx.app.serving.als.model.LoadTestALSModelFactory;
+import com.cloudera.oryx.common.settings.ConfigUtils;
 
 /**
  * Note this test isn't run by default by surefire or failsafe. It is activated by a profile.
@@ -102,13 +104,16 @@ public final class LoadBenchmark extends AbstractALSServingTest {
       extends AbstractALSServingTest.MockManagerInitListener {
     @Override
     protected AbstractALSServingTest.MockServingModelManager getModelManager() {
-      return new MockLoadTestServingModelManager();
+      return new MockLoadTestServingModelManager(ConfigUtils.getDefault());
     }
   }
 
   private static final class MockLoadTestServingModelManager
       extends AbstractALSServingTest.MockServingModelManager {
     private final ALSServingModel model = LoadTestALSModelFactory.buildTestModel();
+    private MockLoadTestServingModelManager(Config config) {
+      super(config);
+    }
     @Override
     public ALSServingModel getModel() {
       return model;

--- a/app/oryx-app-serving/src/test/java/com/cloudera/oryx/app/serving/als/model/ALSServingModelTest.java
+++ b/app/oryx-app-serving/src/test/java/com/cloudera/oryx/app/serving/als/model/ALSServingModelTest.java
@@ -72,45 +72,45 @@ public final class ALSServingModelTest extends OryxTest {
   }
 
   @Test
-  public void testPruneXY() {
+  public void testRetainUsersItems() {
     ALSServingModel model = new ALSServingModel(2, true, 1.0, null);
 
     model.setUserVector("U0", new float[] { 1.0f, 1.0f });
-    model.pruneX(Collections.<String>emptyList());
+    model.retainRecentAndUserIDs(Collections.<String>emptyList());
     // Protected because of recent user/items
     assertNotNull(model.getUserVector("U0"));
-    model.pruneX(Collections.<String>emptyList());
+    model.retainRecentAndUserIDs(Collections.<String>emptyList());
     assertNull(model.getUserVector("U0"));
 
     model.setUserVector("U0", new float[] { 1.0f, 1.0f });
-    model.pruneX(Arrays.asList("U0"));
+    model.retainRecentAndUserIDs(Arrays.asList("U0"));
     assertNotNull(model.getUserVector("U0"));
-    model.pruneX(Arrays.asList("U0"));
+    model.retainRecentAndUserIDs(Arrays.asList("U0"));
     assertNotNull(model.getUserVector("U0"));
 
     model.setItemVector("I0", new float[]{1.0f, 1.0f});
-    model.pruneY(Collections.<String>emptyList());
+    model.retainRecentAndItemIDs(Collections.<String>emptyList());
     // Protected because of recent user/items
     assertNotNull(model.getItemVector("I0"));
-    model.pruneY(Collections.<String>emptyList());
+    model.retainRecentAndItemIDs(Collections.<String>emptyList());
     assertNull(model.getItemVector("I0"));
 
     model.setItemVector("I0", new float[]{1.0f, 1.0f});
-    model.pruneY(Arrays.asList("I0"));
+    model.retainRecentAndItemIDs(Arrays.asList("I0"));
     assertNotNull(model.getItemVector("I0"));
-    model.pruneY(Arrays.asList("I0"));
+    model.retainRecentAndItemIDs(Arrays.asList("I0"));
     assertNotNull(model.getItemVector("I0"));
   }
 
   @Test
-  public void testPruneKnown() {
+  public void testRetainKnown() {
     ALSServingModel model = new ALSServingModel(2, true, 1.0, null);
     populateKnownItems(model);
     for (int i = 0; i < 10; i++) {
       model.setUserVector("U" + i, new float[] { 0.0f, 0.0f });
       model.setItemVector("I" + i, new float[]{0.0f, 0.0f});
     }
-    model.pruneKnownItems(Arrays.asList("U4", "U5", "U6"), Arrays.asList("I4", "I5", "I6"));
+    model.retainRecentAndKnownItems(Arrays.asList("U4", "U5", "U6"), Arrays.asList("I4", "I5", "I6"));
     assertTrue(model.getKnownItems("U3").contains("I4"));
     assertTrue(model.getKnownItems("U4").contains("I4"));
     assertTrue(model.getKnownItems("U6").contains("I6"));
@@ -119,10 +119,10 @@ public final class ALSServingModelTest extends OryxTest {
     assertTrue(model.getKnownItems("U2").contains("I2"));
 
     // Clears recent user/items
-    model.pruneX(Collections.<String>emptyList());
-    model.pruneY(Collections.<String>emptyList());
+    model.retainRecentAndUserIDs(Collections.<String>emptyList());
+    model.retainRecentAndItemIDs(Collections.<String>emptyList());
 
-    model.pruneKnownItems(Arrays.asList("U4", "U5", "U6"), Arrays.asList("I4", "I5", "I6"));
+    model.retainRecentAndKnownItems(Arrays.asList("U4", "U5", "U6"), Arrays.asList("I4", "I5", "I6"));
     assertNull(model.getKnownItems("U3"));
     assertTrue(model.getKnownItems("U4").contains("I4"));
     assertTrue(model.getKnownItems("U6").contains("I6"));
@@ -216,6 +216,19 @@ public final class ALSServingModelTest extends OryxTest {
     }
     log.info("Mean matching prefix: {}", meanMatchLength.getResult());
     assertTrue(meanMatchLength.getResult() >= 5.0);
+  }
+
+  @Test
+  public void testFractionLoaded() {
+    assertEquals(1.0f, new ALSServingModel(2, true, 1.0, null).getFractionLoaded());
+    ALSServingModel model = new ALSServingModel(2, true, 1.0, null);
+    model.retainRecentAndUserIDs(Collections.singleton("U1"));
+    model.retainRecentAndItemIDs(Collections.singleton("I0"));
+    assertEquals(0.0f, model.getFractionLoaded());
+    model.setUserVector("U1", new float[] { 1.5f, -2.5f });
+    assertEquals(0.5f, model.getFractionLoaded());
+    model.setItemVector("I0", new float[]{0.5f, 0.0f});
+    assertEquals(1.0f, model.getFractionLoaded());
   }
 
 }

--- a/app/oryx-app-serving/src/test/java/com/cloudera/oryx/app/serving/kmeans/AbstractKMeansServingTest.java
+++ b/app/oryx-app-serving/src/test/java/com/cloudera/oryx/app/serving/kmeans/AbstractKMeansServingTest.java
@@ -21,9 +21,12 @@ import javax.servlet.ServletContextListener;
 import java.util.Arrays;
 import java.util.List;
 
+import com.typesafe.config.Config;
+
 import com.cloudera.oryx.app.serving.AbstractOryxResource;
 import com.cloudera.oryx.app.serving.kmeans.model.KMeansServingModel;
 import com.cloudera.oryx.app.serving.kmeans.model.TestKMeansModelFactory;
+import com.cloudera.oryx.common.settings.ConfigUtils;
 import com.cloudera.oryx.lambda.serving.AbstractServingTest;
 import com.cloudera.oryx.lambda.serving.MockTopicProducer;
 
@@ -43,12 +46,16 @@ public abstract class AbstractKMeansServingTest extends AbstractServingTest {
     @Override
     public final void contextInitialized(ServletContextEvent sce) {
       ServletContext context = sce.getServletContext();
-      context.setAttribute(AbstractOryxResource.MODEL_MANAGER_KEY, new MockServingModelManager());
+      context.setAttribute(AbstractOryxResource.MODEL_MANAGER_KEY,
+                           new MockServingModelManager(ConfigUtils.getDefault()));
       context.setAttribute(AbstractOryxResource.INPUT_PRODUCER_KEY, new MockTopicProducer());
     }
   }
 
   protected static class MockServingModelManager extends AbstractMockServingModelManager {
+    public MockServingModelManager(Config config) {
+      super(config);
+    }
     @Override
     public KMeansServingModel getModel() {
       return TestKMeansModelFactory.buildTestModel();

--- a/app/oryx-app-serving/src/test/java/com/cloudera/oryx/app/serving/rdf/AbstractRDFServingTest.java
+++ b/app/oryx-app-serving/src/test/java/com/cloudera/oryx/app/serving/rdf/AbstractRDFServingTest.java
@@ -22,10 +22,13 @@ import javax.ws.rs.core.GenericType;
 import java.util.Arrays;
 import java.util.List;
 
+import com.typesafe.config.Config;
+
 import com.cloudera.oryx.app.serving.AbstractOryxResource;
 import com.cloudera.oryx.app.serving.IDValue;
 import com.cloudera.oryx.app.serving.rdf.model.RDFServingModel;
 import com.cloudera.oryx.app.serving.rdf.model.TestRDFRegressionModelFactory;
+import com.cloudera.oryx.common.settings.ConfigUtils;
 import com.cloudera.oryx.lambda.serving.AbstractServingTest;
 import com.cloudera.oryx.lambda.serving.MockTopicProducer;
 
@@ -48,12 +51,16 @@ public abstract class AbstractRDFServingTest extends AbstractServingTest {
     @Override
     public final void contextInitialized(ServletContextEvent sce) {
       ServletContext context = sce.getServletContext();
-      context.setAttribute(AbstractOryxResource.MODEL_MANAGER_KEY, new MockServingModelManager());
+      context.setAttribute(AbstractOryxResource.MODEL_MANAGER_KEY,
+                           new MockServingModelManager(ConfigUtils.getDefault()));
       context.setAttribute(AbstractOryxResource.INPUT_PRODUCER_KEY, new MockTopicProducer());
     }
   }
 
   protected static class MockServingModelManager extends AbstractMockServingModelManager {
+    public MockServingModelManager(Config config) {
+      super(config);
+    }
     @Override
     public RDFServingModel getModel() {
       return TestRDFRegressionModelFactory.buildTestModel();

--- a/app/oryx-app-serving/src/test/java/com/cloudera/oryx/app/serving/rdf/ClassificationDistributionTest.java
+++ b/app/oryx-app-serving/src/test/java/com/cloudera/oryx/app/serving/rdf/ClassificationDistributionTest.java
@@ -22,6 +22,7 @@ import javax.ws.rs.core.MediaType;
 
 import java.util.List;
 
+import com.typesafe.config.Config;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -30,6 +31,7 @@ import com.cloudera.oryx.app.serving.IDValue;
 import com.cloudera.oryx.app.serving.rdf.model.RDFServingModel;
 import com.cloudera.oryx.app.serving.rdf.model.TestRDFClassificationModelFactory;
 import com.cloudera.oryx.common.OryxTest;
+import com.cloudera.oryx.common.settings.ConfigUtils;
 import com.cloudera.oryx.lambda.serving.MockTopicProducer;
 
 public final class ClassificationDistributionTest extends AbstractRDFServingTest {
@@ -80,13 +82,16 @@ public final class ClassificationDistributionTest extends AbstractRDFServingTest
     public final void contextInitialized(ServletContextEvent sce) {
       ServletContext context = sce.getServletContext();
       context.setAttribute(AbstractOryxResource.MODEL_MANAGER_KEY,
-                           new MockClassificationServingModelManager());
+                           new MockClassificationServingModelManager(ConfigUtils.getDefault()));
       context.setAttribute(AbstractOryxResource.INPUT_PRODUCER_KEY, new MockTopicProducer());
     }
   }
 
   protected static class MockClassificationServingModelManager
       extends AbstractMockServingModelManager {
+    public MockClassificationServingModelManager(Config config) {
+      super(config);
+    }
     @Override
     public RDFServingModel getModel() {
       return TestRDFClassificationModelFactory.buildTestModel();

--- a/app/oryx-app/src/test/java/com/cloudera/oryx/app/speed/als/ALSSpeedModelTest.java
+++ b/app/oryx-app/src/test/java/com/cloudera/oryx/app/speed/als/ALSSpeedModelTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2015, Cloudera, Inc. All Rights Reserved.
+ *
+ * Cloudera, Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"). You may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for
+ * the specific language governing permissions and limitations under the
+ * License.
+ */
+
+package com.cloudera.oryx.app.speed.als;
+
+import java.util.Collections;
+
+import org.junit.Test;
+
+import com.cloudera.oryx.common.OryxTest;
+
+public final class ALSSpeedModelTest extends OryxTest {
+
+  @Test
+  public void testUserItemVector() {
+    ALSSpeedModel model = new ALSSpeedModel(2);
+    assertEquals(2, model.getFeatures());
+    model.setUserVector("U1", new float[] { 1.5f, -2.5f });
+    assertArrayEquals(new float[] { 1.5f, -2.5f }, model.getUserVector("U1"));
+    model.setItemVector("I0", new float[]{0.5f, 0.0f});
+    assertArrayEquals(new float[] { 0.5f, 0.0f }, model.getItemVector("I0"));
+  }
+
+  @Test
+  public void testToString() {
+    String modelToString = new ALSSpeedModel(2).toString();
+    assertTrue(modelToString.contains("ALSSpeedModel"));
+    assertTrue(modelToString.contains("features:2"));
+  }
+
+  @Test
+  public void testFractionLoaded() {
+    assertEquals(1.0f, new ALSSpeedModel(2).getFractionLoaded());
+    ALSSpeedModel model = new ALSSpeedModel(2);
+    model.retainRecentAndUserIDs(Collections.singleton("U1"));
+    model.retainRecentAndItemIDs(Collections.singleton("I0"));
+    assertEquals(0.0f, model.getFractionLoaded());
+    model.setUserVector("U1", new float[] { 1.5f, -2.5f });
+    assertEquals(0.5f, model.getFractionLoaded());
+    model.setItemVector("I0", new float[]{0.5f, 0.0f});
+    assertEquals(1.0f, model.getFractionLoaded());
+  }
+
+}

--- a/framework/oryx-api/src/main/java/com/cloudera/oryx/api/serving/ServingModelManager.java
+++ b/framework/oryx-api/src/main/java/com/cloudera/oryx/api/serving/ServingModelManager.java
@@ -19,6 +19,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.util.Iterator;
 
+import com.typesafe.config.Config;
 import org.apache.hadoop.conf.Configuration;
 
 import com.cloudera.oryx.api.KeyMessage;
@@ -42,6 +43,11 @@ public interface ServingModelManager<U> extends Closeable {
    * @throws IOException if an error occurs while reading updates
    */
   void consume(Iterator<KeyMessage<String,U>> updateIterator, Configuration hadoopConf) throws IOException;
+
+  /**
+   * @return configuration for the serving layer
+   */
+  Config getConfig();
 
   /**
    * @return in-memory model representation

--- a/framework/oryx-api/src/main/scala/com/cloudera/oryx/api/serving/ScalaServingModelManager.scala
+++ b/framework/oryx-api/src/main/scala/com/cloudera/oryx/api/serving/ScalaServingModelManager.scala
@@ -16,6 +16,7 @@
 package com.cloudera.oryx.api.serving
 
 import com.cloudera.oryx.api.KeyMessage
+import com.typesafe.config.Config
 import org.apache.hadoop.conf.Configuration
 
 /**
@@ -34,6 +35,11 @@ trait ScalaServingModelManager[U] {
    * @param hadoopConf Hadoop context, which may be required for reading from HDFS
    */
   def consume(updateIterator: Iterator[KeyMessage[String,U]], hadoopConf: Configuration): Unit
+
+  /**
+   * @return configuration for the serving layer
+   */
+  def getConfig: Config
 
   /**
    * @return in-memory model representation

--- a/framework/oryx-common/src/main/resources/reference.conf
+++ b/framework/oryx-common/src/main/resources/reference.conf
@@ -162,6 +162,9 @@ oryx = {
     # updates from a SpeedModel and stream of input
     model-manager-class = null
 
+    # See doc for serving.min-model-serve-fraction below
+    min-model-load-fraction = 0.8
+
     # Configuration for the Spark UI
     ui = {
       # UI port
@@ -218,6 +221,11 @@ oryx = {
     # Implementation of com.cloudera.oryx.api.serving.ServingModelManager interface
     # that produces a ServingModel from stream of updates
     model-manager-class = null
+
+    # Don't consider a model loaded and ready to use until this fraction of it is loaded.
+    # Some models load incrementally (e.g. ALS). Others load all at once, in which case this
+    # has no effect.
+    min-model-load-fraction = 0.8
 
     # Test-only option; don't set this in general
     no-init-topics = false

--- a/framework/oryx-lambda-serving/src/main/java/com/cloudera/oryx/lambda/serving/ScalaServingModelManagerAdapter.java
+++ b/framework/oryx-lambda-serving/src/main/java/com/cloudera/oryx/lambda/serving/ScalaServingModelManagerAdapter.java
@@ -18,6 +18,7 @@ package com.cloudera.oryx.lambda.serving;
 import java.util.Iterator;
 import java.util.Objects;
 
+import com.typesafe.config.Config;
 import org.apache.hadoop.conf.Configuration;
 import scala.collection.JavaConversions;
 
@@ -42,6 +43,11 @@ public final class ScalaServingModelManagerAdapter<U> implements ServingModelMan
   @Override
   public void consume(Iterator<KeyMessage<String,U>> updateIterator, Configuration hadoopConf) {
     scalaManager.consume(JavaConversions.asScalaIterator(updateIterator), hadoopConf);
+  }
+
+  @Override
+  public Config getConfig() {
+    return scalaManager.getConfig();
   }
 
   @Override

--- a/framework/oryx-lambda-serving/src/test/java/com/cloudera/oryx/lambda/serving/AbstractServingTest.java
+++ b/framework/oryx-lambda-serving/src/test/java/com/cloudera/oryx/lambda/serving/AbstractServingTest.java
@@ -33,6 +33,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import com.google.common.base.Joiner;
+import com.typesafe.config.Config;
 import org.apache.hadoop.conf.Configuration;
 import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.media.multipart.MultiPart;
@@ -169,9 +170,17 @@ public abstract class AbstractServingTest extends JerseyTest {
 
   protected abstract static class AbstractMockServingModelManager
       implements ServingModelManager<String> {
+    private final Config config;
+    protected AbstractMockServingModelManager(Config config) {
+      this.config = config;
+    }
     @Override
     public final void consume(Iterator<KeyMessage<String, String>> updateIterator, Configuration hadoopConf) {
       throw new UnsupportedOperationException();
+    }
+    @Override
+    public final Config getConfig() {
+      return config;
     }
     @Override
     public final void close() {

--- a/framework/oryx-lambda-serving/src/test/java/com/cloudera/oryx/lambda/serving/MockServingModelManager.java
+++ b/framework/oryx-lambda-serving/src/test/java/com/cloudera/oryx/lambda/serving/MockServingModelManager.java
@@ -17,6 +17,7 @@ package com.cloudera.oryx.lambda.serving;
 
 import java.util.Iterator;
 
+import com.typesafe.config.Config;
 import org.apache.hadoop.conf.Configuration;
 
 import com.cloudera.oryx.api.KeyMessage;
@@ -27,6 +28,11 @@ public final class MockServingModelManager implements ServingModelManager<String
   @Override
   public void consume(Iterator<KeyMessage<String, String>> updateIterator, Configuration hadoopConf) {
     // do nothing
+  }
+
+  @Override
+  public Config getConfig() {
+    return null;
   }
 
   @Override


### PR DESCRIPTION
Issue #239 : Add `oryx.{serving,speed}.min-model-load-fraction` to control how much of the model must load in speed or serving layer before it is considered loaded. Only matters for ALS now. Plus a lot of related refactoring