### PR TITLE
spark-submit is now used for batch, speed layer; fixes CDH 5.5 / Spark 1.5 issues

### DIFF
--- a/deploy/bin/compute-classpath.sh
+++ b/deploy/bin/compute-classpath.sh
@@ -13,40 +13,28 @@
 # the specific language governing permissions and limitations under the
 # License.
 
-# CDH5.4+ specific classpath config
+# This is a hacky means to plug in to the versions of libraries used on the cluster
+# rather than ship a particular version with the binaries.
+# TODO: we need a better solution to dependencies
 
-HADOOP_CONF_DIR="/etc/hadoop/conf"
-CDH_JARS_DIR="/opt/cloudera/parcels/CDH/jars"
+# CDH specific classpath config
 
 function printLatest() {
-  ls -1 ${CDH_JARS_DIR}/$1 | grep -E "[0-9]\\.jar$" | tail -1
+  ls -1 /opt/cloudera/parcels/CDH/jars/$1 2>/dev/null | grep -vE "tests.jar$" | tail -1
 }
 
-# Some are known to have multiple versions, and so are fully specified:
-
-echo ${HADOOP_CONF_DIR}
-printLatest "zookeeper-*.jar"
-printLatest "spark-assembly-*.jar"
+# For Spark-based batch and speed layer, the only thing that needs to be supplied, really,
+# are the Kafka libraries that the cluster uses. The Spark Examples jar happens to ship this
+# and is maybe both easier to find and more harmonized than a stand-alone Kafka distro on
+# the cluster, but this is a hacky way to acquire it
 printLatest "spark-examples-*.jar"
-printLatest "hadoop-auth-*.jar"
+
+# The remaining dependencies support the Serving Layer, which needs Hadoop, Kafka,
+# and ZK dependencies
+printLatest "spark-assembly-*.jar"
+printLatest "zookeeper-*.jar"
 printLatest "hadoop-common-*.jar"
-printLatest "hadoop-hdfs-2*.jar"
-printLatest "hadoop-mapreduce-client-core-*.jar"
-printLatest "hadoop-yarn-api-*.jar"
-printLatest "hadoop-yarn-client-*.jar"
-printLatest "hadoop-yarn-common-*.jar"
-printLatest "hadoop-yarn-server-web-proxy-*.jar"
-printLatest "hadoop-yarn-applications-distributedshell-*.jar"
-printLatest "htrace-core-3.*.jar"
-printLatest "commons-cli-1.*.jar"
 printLatest "commons-collections-*.jar"
-printLatest "commons-configuration-1.*.jar"
-printLatest "commons-lang-2.*.jar"
-printLatest "httpclient-4.2.*.jar"
-printLatest "httpcore-4.2.*.jar"
-printLatest "httpmime-4.2.*.jar"
-printLatest "jackson-core-asl-1.9.12.jar"
-printLatest "jackson-mapper-asl-1.9.12.jar"
-printLatest "protobuf-java-*.jar"
-printLatest "snappy-java-*.jar"
-printLatest "avro-1.7.*.jar"
+
+# These are needed for submitting the serving layer in YARN mode
+printLatest "hadoop-yarn-applications-distributedshell-*.jar"

--- a/deploy/bin/oryx-run.sh
+++ b/deploy/bin/oryx-run.sh
@@ -15,9 +15,6 @@
 
 # The file compute-classpath.sh must be in the same directory as this file.
 
-# TODO: remove the '2>&1 | grep -vE "^mkdir: cannot create directory"' used in several
-# Kafka commands below. This suppresses an ignorable warning from the CDH 5.4 distro.
-
 function usageAndExit {
   echo "$1"
   echo "usage: oryx-run.sh command [--option value] ..."
@@ -89,6 +86,16 @@ fi
 
 CONFIG_PROPS=`java -cp ${LAYER_JAR} -Dconfig.file=${CONFIG_FILE} com.cloudera.oryx.common.settings.ConfigToProperties`
 
+# If first arg is FOO and second is bar, and CONFIG_PROPS contains a property bar=baz, then
+# environment variable FOO is set to value baz by this function. The second argument must be
+# expressed as a regular expression; "foo\.bar" not "foo.bar"
+function setVarFromProperty {
+  local __resultvar=$1
+  local property=$2
+  local result=`echo "${CONFIG_PROPS}" | grep -E "^${property}=.+$" | grep -oE "[^=]+$"`
+  eval $__resultvar=$result
+}
+
 # Helps execute kafka-foo or kafka-foo.sh as appropriate.
 # Kind of assume we're using all one or the other
 if [ -x "$(command -v kafka-topics)" ]; then
@@ -119,49 +126,93 @@ batch|speed|serving)
     usageAndExit "$COMPUTE_CLASSPATH script does not exist or isn't executable"
   fi
   BASE_CLASSPATH=`bash ${COMPUTE_CLASSPATH} | paste -s -d: -`
-  # Need to ship examples JAR with app as it conveniently contains right Kafka, in Spark
-  SPARK_EXAMPLES_JAR=`bash ${COMPUTE_CLASSPATH} | grep spark-examples`
-
-  SPARK_STREAMING_JARS="${LAYER_JAR},${SPARK_EXAMPLES_JAR}"
-  if [ "${APP_JAR}" != "" ]; then
-    SPARK_STREAMING_JARS="${APP_JAR},${SPARK_STREAMING_JARS}"
-  fi
-  SPARK_EXECUTOR_JAVA_OPTS="-Dconfig.file=${CONFIG_FILE_NAME} -Dsun.io.serialization.extendeddebuginfo=true"
-  if [ -n "${JVM_ARGS}" ]; then
-    SPARK_EXECUTOR_JAVA_OPTS="${JVM_ARGS} ${SPARK_EXECUTOR_JAVA_OPTS}"
-  fi
-  SPARK_STREAMING_PROPS="-Dspark.yarn.dist.files=${CONFIG_FILE} \
-   -Dspark.jars=${SPARK_STREAMING_JARS} \
-   -Dsun.io.serialization.extendeddebuginfo=true \
-   -Dspark.executor.extraJavaOptions=\"${SPARK_EXECUTOR_JAVA_OPTS}\""
 
   MAIN_CLASS="com.cloudera.oryx.${COMMAND}.Main"
+
+  setVarFromProperty "APP_ID" "oryx\.id"
+
   case "${COMMAND}" in
+  batch|speed)
+    # Need to ship examples JAR with app as it conveniently contains right Kafka, in Spark
+    SPARK_EXAMPLES_JAR=`bash ${COMPUTE_CLASSPATH} | grep spark-examples`
+
+    SPARK_STREAMING_JARS="${SPARK_EXAMPLES_JAR}"
+    if [ -n "${APP_JAR}" ]; then
+      SPARK_STREAMING_JARS="${APP_JAR},${SPARK_STREAMING_JARS}"
+    fi
+    SPARK_JAVA_OPTS="-Dconfig.file=${CONFIG_FILE_NAME}"
+    if [ -n "${JVM_ARGS}" ]; then
+      SPARK_JAVA_OPTS="${JVM_ARGS} ${SPARK_JAVA_OPTS}"
+    fi
+
+    # Force to spark-submit for Spark-based batch/speed layer
+    DEPLOYMENT="spark-submit"
+    case "${COMMAND}" in
     batch)
-      JVM_HEAP_MB=`echo "${CONFIG_PROPS}" | grep -E "^oryx\.batch\.streaming\.driver-memory=.+$" | grep -oE "[^=]+$"`
-      EXTRA_PROPS="-Xmx${JVM_HEAP_MB} ${SPARK_STREAMING_PROPS}"
+      APP_NAME="OryxBatchLayer-${APP_ID}"
       ;;
     speed)
-      JVM_HEAP_MB=`echo "${CONFIG_PROPS}" | grep -E "^oryx\.speed\.streaming\.driver-memory=.+$" | grep -oE "[^=]+$"`
-      EXTRA_PROPS="-Xmx${JVM_HEAP_MB} ${SPARK_STREAMING_PROPS}"
+      APP_NAME="OryxSpeedLayer-${APP_ID}"
       ;;
-    serving)
-      MEMORY_MB=`echo "${CONFIG_PROPS}" | grep -E "^oryx\.serving\.memory=.+$" | grep -oE "[^=]+$" | grep -oE "[0-9]+"`
-      # Only for Serving Layer now
-      if [ "${DEPLOYMENT}" == "yarn" ]; then
-        YARN_CORES=`echo "${CONFIG_PROPS}" | grep -E "^oryx\.serving\.yarn\.cores=.+$" | grep -oE "[^=]+$"`
-        YARN_INSTANCES=`echo "${CONFIG_PROPS}" | grep -E "^oryx\.serving\.yarn\.instances=.+$" | grep -oE "[^=]+$"`
-        APP_ID=`echo "${CONFIG_PROPS}" | grep -E "^oryx\.id=.+$" | grep -oE "[^=]+$"`
-        YARN_APP_NAME="OryxServingLayer-${APP_ID}"
-        JVM_HEAP_MB=`echo "${MEMORY_MB} * 0.9" | bc | grep -oE "^[0-9]+"`
-      else
-        JVM_HEAP_MB=${MEMORY_MB}
-      fi
-      EXTRA_PROPS="-Xmx${JVM_HEAP_MB}m"
+    esac
+
+    setVarFromProperty "SPARK_MASTER" "oryx\.${COMMAND}\.streaming\.master"
+    setVarFromProperty "DRIVER_MEMORY" "oryx\.${COMMAND}\.streaming\.driver-memory"
+    setVarFromProperty "EXECUTOR_MEMORY" "oryx\.${COMMAND}\.streaming\.executor-memory"
+    setVarFromProperty "EXECUTOR_CORES" "oryx\.${COMMAND}\.streaming\.executor-cores"
+    setVarFromProperty "NUM_EXECUTORS" "oryx\.${COMMAND}\.streaming\.num-executors"
+    setVarFromProperty "DYNAMIC_ALLOCATION" "oryx\.${COMMAND}\.streaming\.dynamic-allocation"
+    setVarFromProperty "SPARK_UI_PORT" "oryx\.${COMMAND}\.ui\.port"
+    ;;
+
+  serving)
+    setVarFromProperty "MEMORY_MB" "oryx\.serving\.memory"
+    MEMORY_MB=`echo ${MEMORY_MB} | grep -oE "[0-9]+"`
+    # Only for Serving Layer now
+    case "${DEPLOYMENT}" in
+    yarn)
+      setVarFromProperty "YARN_CORES" "oryx\.serving\.yarn\.cores"
+      setVarFromProperty "YARN_INSTANCES" "oryx\.serving\.yarn\.instances"
+      APP_NAME="OryxServingLayer-${APP_ID}"
+      JVM_HEAP_MB=`echo "${MEMORY_MB} * 0.9" | bc | grep -oE "^[0-9]+"`
       ;;
+    *)
+      JVM_HEAP_MB=${MEMORY_MB}
+      ;;
+    esac
+    EXTRA_PROPS="-Xmx${JVM_HEAP_MB}m"
+    ;;
   esac
 
-  if [ -n "${YARN_APP_NAME}" ]; then
+  case "${DEPLOYMENT}" in
+  spark-submit)
+    # Launch Spark-based layer with spark-submit
+    # TODO the various --conf options are partially duplicated in AbstractSparkLayer for tests;
+    # unify them in the .conf file where both this script and code can access them?
+
+    SPARK_SUBMIT_CMD="spark-submit --master ${SPARK_MASTER} --name ${APP_NAME} --class ${MAIN_CLASS} \
+     --jars ${SPARK_STREAMING_JARS} --files ${CONFIG_FILE} --driver-memory ${DRIVER_MEMORY} \
+     --driver-java-options ${SPARK_JAVA_OPTS} --executor-memory ${EXECUTOR_MEMORY} --executor-cores ${EXECUTOR_CORES} \
+     --conf spark.executor.extraJavaOptions=\"${SPARK_JAVA_OPTS}\" --conf spark.ui.port=${SPARK_UI_PORT} \
+     --conf spark.io.compression.codec=lzf --conf spark.speculation=true --conf spark.logConf=true \
+     --conf spark.serializer=org.apache.spark.serializer.KryoSerializer --conf spark.ui.showConsoleProgress=false "
+    case "${DYNAMIC_ALLOCATION}" in
+    true)
+      SPARK_SUBMIT_CMD="${SPARK_SUBMIT_CMD} --conf spark.dynamicAllocation.enabled=true \
+       --conf spark.dynamicAllocation.minExecutors=1 --conf spark.dynamicAllocation.maxExecutors=${NUM_EXECUTORS} \
+       --conf spark.dynamicAllocation.executorIdleTimeout=60 --conf spark.shuffle.service.enabled=true"
+      ;;
+    *)
+      SPARK_SUBMIT_CMD="${SPARK_SUBMIT_CMD} --num-executors=${NUM_EXECUTORS}"
+      ;;
+    esac
+    SPARK_SUBMIT_CMD="${SPARK_SUBMIT_CMD} ${LAYER_JAR}"
+
+    echo "${SPARK_SUBMIT_CMD}"
+    ${SPARK_SUBMIT_CMD}
+    ;;
+
+  yarn)
     # Launch layer in YARN
 
     LAYER_JAR_NAME=`basename ${LAYER_JAR}`
@@ -170,26 +221,28 @@ batch|speed|serving)
       FINAL_CLASSPATH="${APP_JAR_NAME}:${FINAL_CLASSPATH}"
     fi
 
-    LOCAL_SCRIPT_DIR="/tmp/${YARN_APP_NAME}"
+    LOCAL_SCRIPT_DIR="/tmp/${APP_NAME}"
     LOCAL_SCRIPT="${LOCAL_SCRIPT_DIR}/run-yarn.sh"
     YARN_LOG4J="${LOCAL_SCRIPT_DIR}/log4j.properties"
-    # YARN_APP_NAME will match the base of what distributedshell uses, in the home dir
-    HDFS_APP_DIR="${YARN_APP_NAME}"
+    # APP_NAME will match the base of what distributedshell uses, in the home dir
+    HDFS_APP_DIR="${APP_NAME}"
 
     # Only one copy of the app can be running anyway, so fail if it already seems
     # to be running due to presence of directories
     if [ -d ${LOCAL_SCRIPT_DIR} ]; then
-      usageAndExit "${LOCAL_SCRIPT_DIR} already exists; is ${YARN_APP_NAME} running?"
+      usageAndExit "${LOCAL_SCRIPT_DIR} already exists; is ${APP_NAME} running?"
     fi
     if hdfs dfs -test -d ${HDFS_APP_DIR}; then
-      usageAndExit "${HDFS_APP_DIR} already exists; is ${YARN_APP_NAME} running?"
+      usageAndExit "${HDFS_APP_DIR} already exists; is ${APP_NAME} running?"
     fi
 
     # Make temp directories to stage resources, locally and in HDFS
     mkdir -p ${LOCAL_SCRIPT_DIR}
     hdfs dfs -mkdir -p ${HDFS_APP_DIR}
+    echo "Copying ${LAYER_JAR} and ${CONFIG_FILE} to ${HDFS_APP_DIR}/"
     hdfs dfs -put ${LAYER_JAR} ${CONFIG_FILE} ${HDFS_APP_DIR}/
     if [ -n "${APP_JAR}" ]; then
+      echo "Copying ${APP_JAR} to ${HDFS_APP_DIR}/"
       hdfs dfs -put ${APP_JAR} ${HDFS_APP_DIR}/
     fi
 
@@ -202,7 +255,7 @@ batch|speed|serving)
 
     YARN_DIST_SHELL_JAR=`bash ${COMPUTE_CLASSPATH} | grep distributedshell`
 
-    echo "Running ${YARN_INSTANCES} ${YARN_APP_NAME} (${YARN_CORES} cores / ${MEMORY_MB}MB)"
+    echo "Running ${YARN_INSTANCES} ${APP_NAME} (${YARN_CORES} cores / ${MEMORY_MB}MB)"
     echo "Note that you will need to find the Application Master in YARN to find the Serving Layer"
     echo "instances, and kill the application with 'yarn application -kill [app ID]'"
     echo
@@ -210,7 +263,7 @@ batch|speed|serving)
     yarn jar ${YARN_DIST_SHELL_JAR} \
       -jar ${YARN_DIST_SHELL_JAR} \
       org.apache.hadoop.yarn.applications.distributedshell.Client \
-      -appname ${YARN_APP_NAME} \
+      -appname ${APP_NAME} \
       -container_memory ${MEMORY_MB} \
       -container_vcores ${YARN_CORES} \
       -master_memory 256 \
@@ -225,8 +278,9 @@ batch|speed|serving)
     # Clean up temp dirs; they are only used by this application anyway
     hdfs dfs -rm -r -skipTrash "${HDFS_APP_DIR}"
     rm -r "${LOCAL_SCRIPT_DIR}"
+    ;;
 
-  else
+  *)
     # Launch Layer as local process
 
     FINAL_CLASSPATH="${LAYER_JAR}:${BASE_CLASSPATH}"
@@ -234,18 +288,19 @@ batch|speed|serving)
       FINAL_CLASSPATH="${APP_JAR}:${FINAL_CLASSPATH}"
     fi
     java ${JVM_ARGS} ${EXTRA_PROPS} -Dconfig.file=${CONFIG_FILE} -cp ${FINAL_CLASSPATH} ${MAIN_CLASS}
+    ;;
 
-  fi
+  esac
   ;;
 
 kafka-setup|kafka-tail|kafka-input)
 
-  INPUT_ZK=`echo "${CONFIG_PROPS}" | grep -E "^oryx\.input-topic\.lock\.master=.+$" | grep -oE "[^=]+$"`
-  INPUT_KAFKA=`echo "${CONFIG_PROPS}" | grep -E "^oryx\.input-topic\.broker=.+$" | grep -oE "[^=]+$"`
-  INPUT_TOPIC=`echo "${CONFIG_PROPS}" | grep -E "^oryx\.input-topic\.message\.topic=.+$" | grep -oE "[^=]+$"`
-  UPDATE_ZK=`echo "${CONFIG_PROPS}" | grep -E "^oryx\.update-topic\.lock\.master=.+$" | grep -oE "[^=]+$"`
-  UPDATE_KAFKA=`echo "${CONFIG_PROPS}" | grep -E "^oryx\.update-topic\.broker=.+$" | grep -oE "[^=]+$"`
-  UPDATE_TOPIC=`echo "${CONFIG_PROPS}" | grep -E "^oryx\.update-topic\.message\.topic=.+$" | grep -oE "[^=]+$"`
+  setVarFromProperty "INPUT_ZK" "oryx\.input-topic\.lock\.master"
+  setVarFromProperty "INPUT_KAFKA" "oryx\.input-topic\.broker"
+  setVarFromProperty "INPUT_TOPIC" "oryx\.input-topic\.message\.topic"
+  setVarFromProperty "UPDATE_ZK" "oryx\.update-topic\.lock\.master"
+  setVarFromProperty "UPDATE_KAFKA" "oryx\.update-topic\.broker"
+  setVarFromProperty "UPDATE_TOPIC" "oryx\.update-topic\.message\.topic"
 
   echo "Input   ZK      ${INPUT_ZK}"
   echo "        Kafka   ${INPUT_KAFKA}"
@@ -257,7 +312,7 @@ kafka-setup|kafka-tail|kafka-input)
 
   case "${COMMAND}" in
   kafka-setup)
-    ALL_TOPICS=`${KAFKA_TOPICS_SH} --list --zookeeper ${INPUT_ZK} 2>&1 | grep -vE "^mkdir: cannot create directory"`
+    ALL_TOPICS=`${KAFKA_TOPICS_SH} --list --zookeeper ${INPUT_ZK}`
     echo "All available topics:"
     echo "${ALL_TOPICS}"
     echo
@@ -267,12 +322,12 @@ kafka-setup|kafka-tail|kafka-input)
       case "${CREATE}" in
         y|Y)
           echo "Creating topic ${INPUT_TOPIC}"
-          ${KAFKA_TOPICS_SH} --zookeeper ${INPUT_ZK} --create --replication-factor 1 --partitions 4 --topic ${INPUT_TOPIC} 2>&1 | grep -vE "^mkdir: cannot create directory"
+          ${KAFKA_TOPICS_SH} --zookeeper ${INPUT_ZK} --create --replication-factor 1 --partitions 4 --topic ${INPUT_TOPIC}
           ;;
       esac
     fi
     echo "Status of topic ${INPUT_TOPIC}:"
-    ${KAFKA_TOPICS_SH} --zookeeper ${INPUT_ZK} --describe --topic ${INPUT_TOPIC} 2>&1 | grep -vE "^mkdir: cannot create directory"
+    ${KAFKA_TOPICS_SH} --zookeeper ${INPUT_ZK} --describe --topic ${INPUT_TOPIC}
     echo
 
     if [ -z `echo "${ALL_TOPICS}" | grep ${UPDATE_TOPIC}` ]; then
@@ -280,25 +335,25 @@ kafka-setup|kafka-tail|kafka-input)
       case "${CREATE}" in
         y|Y)
           echo "Creating topic ${UPDATE_TOPIC}"
-          ${KAFKA_TOPICS_SH} --zookeeper ${UPDATE_ZK} --create --replication-factor 1 --partitions 1 --topic ${UPDATE_TOPIC} 2>&1 | grep -vE "^mkdir: cannot create directory"
-          ${KAFKA_TOPICS_SH} --zookeeper ${UPDATE_ZK} --alter --topic ${UPDATE_TOPIC} --config retention.ms=86400000 --config max.message.bytes=16777216 2>&1 | grep -vE "^mkdir: cannot create directory"
+          ${KAFKA_TOPICS_SH} --zookeeper ${UPDATE_ZK} --create --replication-factor 1 --partitions 1 --topic ${UPDATE_TOPIC}
+          ${KAFKA_TOPICS_SH} --zookeeper ${UPDATE_ZK} --alter --topic ${UPDATE_TOPIC} --config retention.ms=86400000 --config max.message.bytes=16777216
           ;;
       esac
     fi
     echo "Status of topic ${UPDATE_TOPIC}:"
-    ${KAFKA_TOPICS_SH} --zookeeper ${UPDATE_ZK} --describe --topic ${UPDATE_TOPIC} 2>&1 | grep -vE "^mkdir: cannot create directory"
+    ${KAFKA_TOPICS_SH} --zookeeper ${UPDATE_ZK} --describe --topic ${UPDATE_TOPIC}
     echo
     ;;
 
   kafka-tail)
-    ${KAFKA_CONSOLE_CONSUMER_SH} --zookeeper ${INPUT_ZK} --whitelist ${INPUT_TOPIC},${UPDATE_TOPIC} --property fetch.message.max.bytes=16777216 2>&1 | grep -vE "^mkdir: cannot create directory"
+    ${KAFKA_CONSOLE_CONSUMER_SH} --zookeeper ${INPUT_ZK} --whitelist ${INPUT_TOPIC},${UPDATE_TOPIC} --property fetch.message.max.bytes=16777216
     ;;
 
   kafka-input)
     if [ ! -f "${INPUT_FILE}" ]; then
       usageAndExit "Input file ${INPUT_FILE} does not exist"
     fi
-    ${KAFKA_CONSOLE_PRODUCER_SH} --broker-list ${INPUT_KAFKA} --topic ${INPUT_TOPIC} < "${INPUT_FILE}" 2>&1 | grep -vE "^mkdir: cannot create directory"
+    ${KAFKA_CONSOLE_PRODUCER_SH} --broker-list ${INPUT_KAFKA} --topic ${INPUT_TOPIC} < "${INPUT_FILE}"
     ;;
 
   esac


### PR DESCRIPTION
Closes issue #154, closes issue #259: spark-submit is now used for batch, speed layer. oryx-run.sh is slightly refactored and improved. compute-classpath.sh and AbstractSparkLayer are simplified. Still to do: later eliminate compute-classpath. Refactor setting of common Spark configs so that they are not duplicated in oryx-run.sh and in AbstractSparkLayer for tests