### PR TITLE
Add example cfg for performing regression with RDF

### DIFF
--- a/app/conf/rdf-classification-example.conf
+++ b/app/conf/rdf-classification-example.conf
@@ -20,7 +20,7 @@ zk-servers = "b01.example.com:2181,b02.example.com:2181/kafka"
 hdfs-base = "hdfs:///user/example/Oryx"
 
 oryx {
-  id = "RDFExample"
+  id = "RDFClassificationExample"
   input-topic {
     broker = ${kafka-brokers}
     lock = {

--- a/app/conf/rdf-regression-example.conf
+++ b/app/conf/rdf-regression-example.conf
@@ -1,0 +1,88 @@
+# Copyright (c) 2015, Cloudera, Inc. All Rights Reserved.
+#
+# Cloudera, Inc. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"). You may not use this file except in
+# compliance with the License. You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# This software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for
+# the specific language governing permissions and limitations under the
+# License.
+
+# A very basic example config file configuring only the essential elements to
+# run a decision forest-based application.
+
+# It's possible to specify reusable values:
+kafka-brokers = "b03.example.com:9092,b04.example.com:9092"
+zk-servers = "b01.example.com:2181,b02.example.com:2181/kafka"
+hdfs-base = "hdfs:///user/example/Oryx"
+
+oryx {
+  id = "RDFExample"
+  input-topic {
+    broker = ${kafka-brokers}
+    lock = {
+      master = ${zk-servers}
+    }
+  }
+  update-topic {
+    broker = ${kafka-brokers}
+    lock = {
+      master = ${zk-servers}
+    }
+  }
+
+  batch {
+    streaming {
+      generation-interval-sec = 300
+      num-executors = 4
+      executor-cores = 8
+      executor-memory = "4g"
+    }
+    update-class = "com.cloudera.oryx.app.batch.mllib.rdf.RDFUpdate"
+    storage {
+      data-dir = ${hdfs-base}"/data/"
+      model-dir = ${hdfs-base}"/model/"
+    }
+    ui {
+      port = 4040
+    }
+  }
+  speed {
+    model-manager-class = "com.cloudera.oryx.app.speed.rdf.RDFSpeedModelManager"
+    ui {
+      port = 4041
+    }
+  }
+  serving {
+    model-manager-class = "com.cloudera.oryx.app.serving.rdf.model.RDFServingModelManager"
+    application-resources = "com.cloudera.oryx.app.serving,com.cloudera.oryx.app.serving.classreg,com.cloudera.oryx.app.serving.rdf"
+    api {
+      port = 8080
+    }
+  }
+
+  # This depends on the input data; example is an fictional dataset
+  input-schema = {
+    feature-names = ["county", "route", "start", "end", "length", "exposure", "threshold", "rate"]
+    categorical-features = ["county", "route", "threshold"]
+    numeric-features = ["start", "end", "length", "exposure", "rate"]
+    target-feature = "rate"
+    num-features = 8
+  }
+
+  # Parameters for rdf; for regression you must specify variance as the impurity measure
+  rdf {
+    hyperparams {
+      "max-depth" = 8
+      "min-node-size" = 16
+      "max-split-candidates" = 100
+      impurity = variance
+      "min-info-gain-nats" = 0.001
+    }
+    "num-trees" = 20
+  }
+
+}

--- a/app/conf/rdf-regression-example.conf
+++ b/app/conf/rdf-regression-example.conf
@@ -20,7 +20,7 @@ zk-servers = "b01.example.com:2181,b02.example.com:2181/kafka"
 hdfs-base = "hdfs:///user/example/Oryx"
 
 oryx {
-  id = "RDFExample"
+  id = "RDFRegressionExample"
   input-topic {
     broker = ${kafka-brokers}
     lock = {

--- a/src/site/markdown/docs/endusers.md
+++ b/src/site/markdown/docs/endusers.md
@@ -220,4 +220,5 @@ Or see one of the following examples:
 
 - [`app/conf/als-example.conf`](https://github.com/OryxProject/oryx/blob/master/app/conf/als-example.conf)
 - [`app/conf/kmeans-example.conf`](https://github.com/OryxProject/oryx/blob/master/app/conf/kmeans-example.conf)
-- [`app/conf/rdf-example.conf`](https://github.com/OryxProject/oryx/blob/master/app/conf/rdf-example.conf)
+- [`app/conf/rdf-classification-example.conf`](https://github.com/OryxProject/oryx/blob/master/app/conf/rdf-classification-example.conf)
+- [`app/conf/rdf-regression-example.conf`](https://github.com/OryxProject/oryx/blob/master/app/conf/rdf-regression-example.conf)


### PR DESCRIPTION
The default example config does not demonstrate how to use RDF for regression tasks.

Doing so requires that you set numeric features as well as the impurity measure in rdf as variance as opposed to entropy.

This config file demonstrates how to use rdf for regression.

Declaration:
This contribution is my original work and I license the work to the project under the project's open source license.

