### PR TITLE
Fix a broken link for ALS algorithm in index page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -77,8 +77,8 @@
 <p>It consists of three <i>tiers</i>, each of which builds on the one below:</p> 
 <ol style="list-style-type: decimal"> 
  <li>A generic lambda architecture tier, providing batch/speed/serving layers, which is not specific to machine learning</li> 
- <li>A specialization on top providing ML abstractions for hyperparameter selection, etc.</li> 
- <li>An end-to-end implementation of the same standard ML algorithms as an application (<a class="externalLink" href="http://labs.yahoo.com/files/HuKorenVolinsky-ICDM08.pdf">ALS</a>, <a class="externalLink" href="http://en.wikipedia.org/wiki/Random_forest">random decision forests</a>, <a class="externalLink" href="http://en.wikipedia.org/wiki/K-means_clustering">k-means</a>) on top</li> 
+ <li>A specialization on top providing ML abstractions for hyperparameter selection, etc.</li>
+ <li>An end-to-end implementation of the same standard ML algorithms as an application (<a class="externalLink" href="http://yifanhu.net/PUB/cf.pdf">ALS</a>, <a class="externalLink" href="http://en.wikipedia.org/wiki/Random_forest">random decision forests</a>, <a class="externalLink" href="http://en.wikipedia.org/wiki/K-means_clustering">k-means</a>) on top</li> 
 </ol> 
 <p>Viewed another way, it contains the three side-by-side cooperating <i>layers</i> of the lambda architecture too, as well as a connecting element:</p> 
 <ol style="list-style-type: decimal"> 

--- a/docs/index.html
+++ b/docs/index.html
@@ -77,7 +77,7 @@
 <p>It consists of three <i>tiers</i>, each of which builds on the one below:</p> 
 <ol style="list-style-type: decimal"> 
  <li>A generic lambda architecture tier, providing batch/speed/serving layers, which is not specific to machine learning</li> 
- <li>A specialization on top providing ML abstractions for hyperparameter selection, etc.</li>
+ <li>A specialization on top providing ML abstractions for hyperparameter selection, etc.</li> 
  <li>An end-to-end implementation of the same standard ML algorithms as an application (<a class="externalLink" href="http://yifanhu.net/PUB/cf.pdf">ALS</a>, <a class="externalLink" href="http://en.wikipedia.org/wiki/Random_forest">random decision forests</a>, <a class="externalLink" href="http://en.wikipedia.org/wiki/K-means_clustering">k-means</a>) on top</li> 
 </ol> 
 <p>Viewed another way, it contains the three side-by-side cooperating <i>layers</i> of the lambda architecture too, as well as a connecting element:</p> 

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -16,7 +16,7 @@ It consists of three _tiers_, each of which builds on the one below:
 specific to machine learning
 1. A specialization on top providing ML abstractions for hyperparameter selection, etc.
 1. An end-to-end implementation of the same standard ML algorithms as an application
-  ([ALS](http://labs.yahoo.com/files/HuKorenVolinsky-ICDM08.pdf),
+  ([ALS](http://yifanhu.net/PUB/cf.pdf),
 [random decision forests](http://en.wikipedia.org/wiki/Random_forest),
 [k-means](http://en.wikipedia.org/wiki/K-means_clustering)) on top
 


### PR DESCRIPTION
This PR proposes to fix the broken ALS algorithm link in http://oryx.io.

It seems the link, http://labs.yahoo.com/files/HuKorenVolinsky-ICDM08.pdf, broken and moved into http://yifanhu.net/PUB/cf.pdf which _I guess_ in the author's private page.

Please close this if it is not considered as an appropriate link as a reference.

(Other links in that page look fine as I was clicking and reading each link in that page)
