### PR TITLE
Fix flaky test PMMLUtilsTest.testToString

### DIFF
--- a/framework/oryx-common/src/test/java/com/cloudera/oryx/common/pmml/PMMLUtilsTest.java
+++ b/framework/oryx-common/src/test/java/com/cloudera/oryx/common/pmml/PMMLUtilsTest.java
@@ -26,6 +26,7 @@ import org.dmg.pmml.tree.CountingLeafNode;
 import org.dmg.pmml.tree.Node;
 import org.dmg.pmml.tree.TreeModel;
 import org.junit.Test;
+import static org.hamcrest.CoreMatchers.*;
 
 import com.cloudera.oryx.common.OryxTest;
 
@@ -65,7 +66,8 @@ public final class PMMLUtilsTest extends OryxTest {
   public void testToString() throws Exception {
     PMML model = buildDummyModel();
     model.getHeader().setTimestamp(null);
-    assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" +
+    assertThat(PMMLUtils.toString(model), anyOf(is(
+                 "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" +
                  "<PMML version=\"4.3\" xmlns=\"http://www.dmg.org/PMML-4_3\" " +
                  "xmlns:data=\"http://jpmml.org/jpmml-model/InlineTable\">" +
                  "<Header>" +
@@ -74,8 +76,19 @@ public final class PMMLUtilsTest extends OryxTest {
                  "<TreeModel functionName=\"classification\">" +
                  "<Node recordCount=\"123.0\"/>" +
                  "</TreeModel>" +
-                 "</PMML>",
-                 PMMLUtils.toString(model));
+                 "</PMML>"), is(
+                 "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" +
+                 "<PMML version=\"4.3\" xmlns:data=\"http://jpmml.org/jpmml-model/InlineTable\" " +
+                 "xmlns=\"http://www.dmg.org/PMML-4_3\">" +
+                 "<Header>" +
+                 "<Application name=\"Oryx\"/>" +
+                 "</Header>" +
+                 "<TreeModel functionName=\"classification\">" +
+                 "<Node recordCount=\"123.0\"/>" +
+                 "</TreeModel>" +
+                 "</PMML>"
+                 )
+    ));
   }
 
   @Test


### PR DESCRIPTION
It is observed that the following test currently check only one possible XML string but another string could also possibly be produced:

-  framework.oryx-common.src.test.com.cloudera.oryx.common.PMML.PMMLUtilsTest.testToString

The reason for this is that the property ordered of PMML model is non-deterministic and therefore the string produced by `marshaller.marshal(pmml, new StreamResult(out))` could have different orders. Another possible patch would be to add `@XmlAccessorOrder` in the PMML object definition in `jpmml`. This fix that `testToString` to assert one of the two possible outcomes.