### PR TITLE
Fix flaky test TextUtilsTest#testJSONMap

### DIFF
--- a/framework/oryx-common/src/test/java/com/cloudera/oryx/common/text/TextUtilsTest.java
+++ b/framework/oryx-common/src/test/java/com/cloudera/oryx/common/text/TextUtilsTest.java
@@ -19,8 +19,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.Test;

--- a/framework/oryx-common/src/test/java/com/cloudera/oryx/common/text/TextUtilsTest.java
+++ b/framework/oryx-common/src/test/java/com/cloudera/oryx/common/text/TextUtilsTest.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.junit.Test;
@@ -120,7 +121,7 @@ public final class TextUtilsTest extends OryxTest {
 
   @Test
   public void testJSONMap() {
-    Map<Object,Object> map = new HashMap<>();
+    Map<Object,Object> map = new LinkedHashMap<>();
     map.put(1, "bar");
     map.put("foo", 2);
     assertEquals("[\"A\",{\"1\":\"bar\",\"foo\":2},\"B\"]",


### PR DESCRIPTION
The test `com.cloudera.oryx.common.text.TextUtilsTest#testJSONMap` compares the result of `TextUtils.joinJSON` to a hard-coded string based on a specific order of entries in `HashMap`. However, these classes do not guarantee that order, and the assertion can fail if the order differs.

The PR uses `LinkedHashMap` to make the order and the string deterministic.